### PR TITLE
Changed evironment to use GUMBO_ENV var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,20 @@
-Themosis framework
-==================
+# Gumbo Millennium Themosis
 
-[![Build Status](https://travis-ci.org/themosis/themosis.svg?branch=dev)](https://travis-ci.org/themosis/themosis)
+Dit is de nieuwe website.
 
-The Themosis framework is a tool aimed to WordPress developers of any levels. But the better WordPress and PHP knowledge you have the easier it is to work with.
+## Development
 
-Themosis framework is a tool to help you develop websites and web applications faster using [WordPress](https://wordpress.org). Using an elegant and simple code syntax, Themosis framework helps you structure and organize your code and allows you to better manage and scale your WordPress websites and applications.
+Gebruik de *Docker* om te werken, of installeer het lokaal en stel de
+environment variabele `GUMBO_ENV` op `local` of `development`
 
-Development team
-----------------
-The framework was created by [Julien Lambé](http://www.themosis.com/), who continues to lead the development.
+Een voorbeeldje voor nginx:
 
-Contributing
-------------
-Any help is appreciated. The project is open-source and we encourage you to participate. You can contribute to the project in multiple ways by:
+```nginx
+server{
+  # ...
 
-- Reporting a bug issue
-- Suggesting features
-- Sending a pull request with code fix or feature
-- Following the project on [GitHub](https://github.com/themosis)
-- Following us on Twitter: [@Themosis](https://twitter.com/Themosis)
-- Sharing the project around your community
+  fastcgi_param GUMBO_ENV development;
 
-For details about contributing to the framework, please check the [contribution guide](http://framework.themosis.com/docs/1.3/contributing).
-
-License
--------
-The Themosis framework is open-source software licensed under [GPL-2+ license](http://www.gnu.org/licenses/gpl-2.0.html).
+  # ...
+}
+```

--- a/config/environment.php
+++ b/config/environment.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Flexibly define the environment to use. Docker uses php.gumbo.example as
+ * hostname, so that's one to check, otherwise look for a GUMBO_ENV environment
+ * global.
+ *
+ * @return string
+ */
+return function () {
+    // Get OS hostname
+    $hostname = gethostname();
+
+    if ($hostname === 'php.gumbo.example') {
+        return 'docker';
+    }
+
+    if (in_array(getenv('GUMBO_ENV'), ['local', 'dev', 'development'])) {
+        return 'local';
+    }
+
+    return 'production';
+};


### PR DESCRIPTION
Better than using hostnames and shit.

Add a `GUMBO_ENV` evironment variable with value `development` to enable dev mode, otherwise it's in production. Alternative 2: Use the Docker.